### PR TITLE
Remove Section 12 (Privacy) from requirement chapters

### DIFF
--- a/index.md
+++ b/index.md
@@ -82,9 +82,8 @@ Most production systems should aim for at least Level 2.
 9. [Autonomous Orchestration & Agentic Action Security](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md)
 10. [MCP Security](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C10-MCP-Security.md)
 11. [Adversarial Robustness & Attack Resistance](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C11-Adversarial-Robustness.md)
-12. [Privacy Protection & Personal Data Management](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C12-Privacy.md)
-13. [Monitoring, Logging & Anomaly Detection](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C13-Monitoring-and-Logging.md)
-14. [Human Oversight and Trust](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C14-Human-Oversight.md)
+12. [Monitoring, Logging & Anomaly Detection](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C13-Monitoring-and-Logging.md)
+13. [Human Oversight and Trust](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C14-Human-Oversight.md)
 
 ### Appendices
 


### PR DESCRIPTION
Fully removes Section 12 (Privacy Protection & Personal Data Management) from the requirement chapters list in `index.md`.

- Deleted the Privacy line.
- Renumbered display numbers so Monitoring/Logging is now 12 and Human Oversight is now 13.
- Left the underlying chapter file codes (`C13`, `C14`) in the URLs unchanged, since those match the actual filenames in the OWASP/AISVS repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)