### PR TITLE
Update chapter list to 12-chapter AISVS structure

### DIFF
--- a/index.md
+++ b/index.md
@@ -82,8 +82,7 @@ Most production systems should aim for at least Level 2.
 9. [Autonomous Orchestration & Agentic Action Security](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md)
 10. [MCP Security](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C10-MCP-Security.md)
 11. [Adversarial Robustness & Attack Resistance](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C11-Adversarial-Robustness.md)
-12. [Monitoring, Logging & Anomaly Detection](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C13-Monitoring-and-Logging.md)
-13. [Human Oversight and Trust](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C14-Human-Oversight.md)
+12. [Monitoring, Logging & Anomaly Detection](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C12-Monitoring-and-Logging.md)
 
 ### Appendices
 
@@ -91,6 +90,7 @@ Most production systems should aim for at least Level 2.
 * [Appendix B: References](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x91-Appendix-B_References.md)
 * [Appendix C: AI-Assisted Secure Coding](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x92-Appendix-C_AI_for_Code_Generation.md)
 * [Appendix D: AI Security Controls Inventory](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md)
+* [Appendix E: Contributors](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x94-Appendix-E_Contributors.md)
 
 ### Road Map
 


### PR DESCRIPTION
Aligns the docs site (`index.md`) with the current `OWASP/AISVS` source repo, which now has 12 requirement chapters.

## Changes
- **Removed** the deleted *Human Oversight and Trust* (C14) chapter — it no longer exists upstream.
- **Renumbered** *Monitoring, Logging & Anomaly Detection* to C12 and corrected its link (was `C13`).
- **Added** the new *Appendix E: Contributors*.

Verified against `OWASP/AISVS` `1.0/en/` (chapters C01–C12). Grepped the rest of the repo for stale references to the removed chapter — none found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)